### PR TITLE
Update allowed host for Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   base: '/edimara_law/',            // << importante para carregar assets no Pages
   resolve: { alias: { '@': path.resolve(__dirname, './src') } },
   server: {
-    allowedHosts: ['bcbeb348b823.ngrok-free.app'],
+    allowedHosts: ['1743b3df390e.ngrok-free.app'],
   },
 })


### PR DESCRIPTION
## Summary
- update the Vite dev server configuration to allow the new ngrok host

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbf9b9da0832899f4b036d8852a33